### PR TITLE
fixed png format downloading

### DIFF
--- a/components/WordCloud/WordCloud.tsx
+++ b/components/WordCloud/WordCloud.tsx
@@ -1,7 +1,7 @@
 import CloudLayout, { LayoutConfig } from '../../lib/classes/CloudLayout';
 import * as d3 from 'd3';
 import d3Cloud from 'd3-cloud';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface WordCloudProps {
 	wordArray: { text: string; size: number; enabled: boolean }[];
@@ -10,6 +10,7 @@ interface WordCloudProps {
 }
 
 const WordCloud = ({ wordArray, size, config }: WordCloudProps) => {
+	const [isLoaded, setIsLoaded] = useState(false);
 	const cl = new CloudLayout(
 		size,
 		wordArray,
@@ -21,6 +22,11 @@ const WordCloud = ({ wordArray, size, config }: WordCloudProps) => {
 		removeCloud();
 		// This calls draw
 		cl.start();
+
+		// Binds the generated svg to the canvas
+		(async () => {
+			await cl.bind();
+		})();
 	});
 
 	function removeCloud() {
@@ -45,13 +51,6 @@ const WordCloud = ({ wordArray, size, config }: WordCloudProps) => {
 			.selectAll('text')
 			.data(word as d3Cloud.Word[]);
 
-		// Set its transition properties
-		wordContainer
-			.transition()
-			.duration(500)
-			.attr('transfrom', (d) => `translate(${[d.x, d.y]})rotate(${d.rotate})`)
-			.style('font-size', (d) => d.size + 'px');
-
 		// Apend the new text svg element and sets its rotation
 		wordContainer
 			.enter()
@@ -59,15 +58,18 @@ const WordCloud = ({ wordArray, size, config }: WordCloudProps) => {
 			.attr('text-anchor', 'middle')
 			.attr('transform', (d) => `translate(${[d.x, d.y]})rotate(${d.rotate})`)
 			.style('font-size', '1px')
-			.transition()
-			.duration(500)
 			.style('font-size', (d) => d.size + 'px')
 			.style('font-family', (d) => d.font as string)
 			.style('fill', '#262626')
 			.text((d) => d.text as string);
 	}
 
-	return <div id='cloud-wrapper' className='select-none'></div>;
+	return (
+		<>
+			<div id='cloud-wrapper' className='select-none hidden'></div>
+			<canvas id='wc-canvas' className='' />
+		</>
+	);
 };
 
 export default WordCloud;

--- a/lib/classes/CloudLayout.ts
+++ b/lib/classes/CloudLayout.ts
@@ -1,6 +1,7 @@
 import d3Cloud from 'd3-cloud';
 import * as d3 from 'd3';
 import type { Rotation, Word } from '../types';
+import { Canvg, RenderingContext2D } from 'canvg';
 
 export type LayoutConfig = {
 	font?: string;
@@ -75,6 +76,17 @@ class CloudLayout {
 	/* Returns the d3Cloud layout object and runs start method on it,
   which initialiazes the word placement algorithm from d3Cloud */
 	start = () => this._layout().start();
+
+	bind = async () => {
+		const svg = document.getElementById('wc-svg')?.outerHTML as string;
+		const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+		const ctx = canvas.getContext('2d') as RenderingContext2D;
+		const v = await Canvg.from(ctx, svg);
+		v.start();
+		window.onbeforeunload = () => {
+			v.stop();
+		};
+	};
 
 	private _layout = () => {
 		// filter out words with !enabled and pass it to d3Cloud lauyout builder

--- a/lib/classes/Downloader.ts
+++ b/lib/classes/Downloader.ts
@@ -1,5 +1,3 @@
-import { Canvg, RenderingContext2D, presets } from 'canvg';
-
 class Downloader {
 	id;
 	el;
@@ -20,29 +18,9 @@ class Downloader {
 		this._downloadAction(uri, fileName);
 	}
 
-	async asPNG(fileName: string) {
-		const preset = presets.offscreen();
-		let canvas;
-		try {
-			canvas = new OffscreenCanvas(
-				this.el?.clientWidth as number,
-				this.el?.clientHeight as number
-			);
-		} catch {
-			alert('Currently only supported in Google Chrome, working on a fix');
-			return;
-		}
-		const ctx = canvas.getContext('2d');
-		const v = await Canvg.from(
-			ctx as RenderingContext2D,
-			this.el?.outerHTML as string,
-			preset
-		);
-		await v.render();
-
-		const blob = await canvas.convertToBlob();
-		const uri = URL.createObjectURL(blob);
-
+	asPNG(fileName: string) {
+		const canvas = document.querySelector('canvas') as HTMLCanvasElement;
+		const uri = canvas.toDataURL('image/png');
 		this._downloadAction(uri, fileName);
 	}
 


### PR DESCRIPTION
Convert svg to canvas in DOM, this allows downloading as PNG or JPG formats, this is a temporary solution until OffScreenCanvas is supported in more browsers. Rendering as svg on DOM is better as canvas is blurry